### PR TITLE
Add -e to grep options in bin/regex-grep*

### DIFF
--- a/bin/regex-grep
+++ b/bin/regex-grep
@@ -39,7 +39,7 @@ DEFAULT_CUST_OPS=""
 #      This will be replaced either with custom options
 #      or with the default options.
 
-MY_CHECK="grep --color=always -inHE \"__CUSTOM_OPT_PLACEHOLDER__\" \"\$1\" || true"
+MY_CHECK="grep --color=always -inHE -e \"__CUSTOM_OPT_PLACEHOLDER__\" \"\$1\" || true"
 
 # Can this check fix the problems?
 ENABLE_FIX=0

--- a/bin/regex-grep-negative
+++ b/bin/regex-grep-negative
@@ -39,7 +39,7 @@ DEFAULT_CUST_OPS=""
 #      This will be replaced either with custom options
 #      or with the default options.
 
-MY_CHECK="grep -iLE \"__CUSTOM_OPT_PLACEHOLDER__\" \"\$1\" || true"
+MY_CHECK="grep -iLE -e \"__CUSTOM_OPT_PLACEHOLDER__\" \"\$1\" || true"
 
 # Can this check fix the problems?
 ENABLE_FIX=0


### PR DESCRIPTION
If a search pattern is sent to grep that starts with a hyphen, grep will
fail.  This commit adds the '-e' flag to grep signaling that the next
option (`\"__CUSTOM_OPT_PLACEHOLDER__\"`) is the search pattern.

This addresses issue #15 